### PR TITLE
Align friction defaults with Newton ShapeConfig after PR #1681

### DIFF
--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -428,7 +428,7 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
     By applying this schema, the prim also inherits the `PhysicsMaterialAPI` schema."""
 )
 {
-    float newton:torsionalFriction = 0.25 (
+    float newton:torsionalFriction = 0.005 (
         doc = """Torsional friction coefficient (resistance to spinning at a contact point).
 
         Range: [0, inf)
@@ -440,7 +440,7 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         }
     )
 
-    float newton:rollingFriction = 0.0005 (
+    float newton:rollingFriction = 0.0001 (
         doc = """Rolling friction coefficient (resistance to rolling motion).
 
         Range: [0, inf)

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -42,7 +42,7 @@ class TestNewtonMaterialAPI(unittest.TestCase):
         attr = self.material.GetAttribute("newton:torsionalFriction")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertAlmostEqual(attr.Get(), 0.25)
+        self.assertAlmostEqual(attr.Get(), 0.005)
 
         success = attr.Set(0.1)
         self.assertTrue(success)
@@ -62,7 +62,7 @@ class TestNewtonMaterialAPI(unittest.TestCase):
         attr = self.material.GetAttribute("newton:rollingFriction")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertAlmostEqual(attr.Get(), 0.0005)
+        self.assertAlmostEqual(attr.Get(), 0.0001)
 
         success = attr.Set(0.01)
         self.assertTrue(success)


### PR DESCRIPTION
## Description

Newton PR #1681 (2026-02-18) changed ShapeConfig defaults to match MuJoCo:
 - mu_torsional 0.25 → 0.005
 - mu_rolling 0.0005 → 0.0001

The USD schema fallbacks were not updated, causing silent behavioral divergence between USD-authored and API-authored simulations.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/newton-usd-schemas/blob/HEAD/CONTRIBUTING.md).
