### PR TITLE
Add contact penalty attributes to NewtonCollisionAPI

### DIFF
--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -474,6 +474,60 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
+    float newton:contactStiffness = 2500 (
+        doc = """Spring constant of the penalty contact model.
+
+        Higher values produce stiffer contacts at the cost of requiring smaller time steps.
+
+        Range: [0, inf)
+        Units: force/distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
+    float newton:contactDamping = 100 (
+        doc = """Damping coefficient of the penalty contact model.
+
+        Dissipates energy during contact to reduce bouncing.
+
+        Range: [0, inf)
+        Units: force * time / distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
+    float newton:contactFrictionStiffness = 1000 (
+        doc = """Stiffness of the tangential friction response.
+
+        At low sliding speeds, friction force equals `kf * velocity` (viscous regime); at high speeds
+        it is clamped to the Coulomb limit `mu * normal_force`.
+
+        Range: [0, inf)
+        Units: force * time / distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
+    float newton:contactAdhesion = 0 (
+        doc = """Contact adhesion distance.
+
+        When two surfaces are within this distance, an attractive force pulls them together.
+        A value of 0 disables adhesion.
+
+        Range: [0, inf)
+        Units: distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
 }
 
 class NewtonMeshCollisionAPI "NewtonMeshCollisionAPI" (

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -504,13 +504,13 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
-    float newton:contactFrictionStiffness = -inf (
-        doc = """Stiffness of the tangential friction response.
+    float newton:contactFrictionDamping = -inf (
+        doc = """Damping of the tangential friction response.
 
         At low sliding speeds, friction force equals `kf * velocity` (viscous regime); at high speeds
         it is clamped to the Coulomb limit `mu * normal_force`.
 
-        If `newton:contactFrictionStiffness` is set to `-inf`, the engine's default should be used instead.
+        If `newton:contactFrictionDamping` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force * time / distance"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -464,7 +464,7 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
 
         Increasing `newton:contactGap` helps avoid tunneling by detecting contacts earlier.
 
-        If `newton:contactGap` is set to `-inf`, Newton's builder default should be used instead.
+        If `newton:contactGap` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: distance"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -474,10 +474,12 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
-    float newton:contactStiffness = 2500 (
+    float newton:contactStiffness = -inf (
         doc = """Spring constant of the penalty contact model.
 
         Higher values produce stiffer contacts at the cost of requiring smaller time steps.
+
+        If `newton:contactStiffness` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force/distance"""
@@ -487,10 +489,12 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
-    float newton:contactDamping = 100 (
+    float newton:contactDamping = -inf (
         doc = """Damping coefficient of the penalty contact model.
 
         Dissipates energy during contact to reduce bouncing.
+
+        If `newton:contactDamping` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force * time / distance"""
@@ -500,12 +504,14 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
-    float newton:contactFrictionStiffness = 1000 (
+    float newton:contactFrictionStiffness = -inf (
         doc = """Stiffness of the tangential friction response.
 
         At low sliding speeds, friction force equals `kf * velocity` (viscous regime); at high speeds
         it is clamped to the Coulomb limit `mu * normal_force`.
 
+        If `newton:contactFrictionStiffness` is set to `-inf`, the engine's default should be used instead.
+
         Range: [0, inf)
         Units: force * time / distance"""
         limits = {
@@ -514,11 +520,13 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
-    float newton:contactAdhesion = 0 (
+    float newton:contactAdhesion = -inf (
         doc = """Contact adhesion distance.
 
         When two surfaces are within this distance, an attractive force pulls them together.
         A value of 0 disables adhesion.
+
+        If `newton:contactAdhesion` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: distance"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -504,13 +504,13 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
-    float newton:contactFrictionDamping = -inf (
-        doc = """Damping of the tangential friction response.
+    float newton:contactFrictionStiffness = -inf (
+        doc = """Stiffness of the tangential friction response.
 
-        At low sliding speeds, friction force equals `kf * velocity` (viscous regime); at high speeds
-        it is clamped to the Coulomb limit `mu * normal_force`.
+        At low sliding speeds, friction force equals `contactFrictionStiffness * velocity`
+        (viscous regime); at high speeds it is clamped to the Coulomb limit `mu * normal_force`.
 
-        If `newton:contactFrictionDamping` is set to `-inf`, the engine's default should be used instead.
+        If `newton:contactFrictionStiffness` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force * time / distance"""

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -34,7 +34,7 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         self.assertTrue(self.prim.HasAttribute("newton:contactGap"))  # from NewtonCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactStiffness"))  # from NewtonCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactDamping"))  # from NewtonCollisionAPI
-        self.assertTrue(self.prim.HasAttribute("newton:contactFrictionStiffness"))  # from NewtonCollisionAPI
+        self.assertTrue(self.prim.HasAttribute("newton:contactFrictionDamping"))  # from NewtonCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactAdhesion"))  # from NewtonCollisionAPI
         # SDF/hydro attrs should NOT be present on bare NewtonCollisionAPI
         self.assertFalse(self.prim.HasAttribute("newton:sdfMaxResolution"))
@@ -124,11 +124,11 @@ class TestNewtonCollisionAPI(unittest.TestCase):
             self.assertAlmostEqual(soft.GetMinimum(), 0.0)
             self.assertIsNone(soft.GetMaximum())
 
-    def test_contact_friction_stiffness(self):
-        self.assertFalse(self.prim.HasAttribute("newton:contactFrictionStiffness"))
+    def test_contact_friction_damping(self):
+        self.assertFalse(self.prim.HasAttribute("newton:contactFrictionDamping"))
 
         self.prim.ApplyAPI("NewtonCollisionAPI")
-        attr = self.prim.GetAttribute("newton:contactFrictionStiffness")
+        attr = self.prim.GetAttribute("newton:contactFrictionDamping")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), -math.inf)

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -34,7 +34,7 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         self.assertTrue(self.prim.HasAttribute("newton:contactGap"))  # from NewtonCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactStiffness"))  # from NewtonCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactDamping"))  # from NewtonCollisionAPI
-        self.assertTrue(self.prim.HasAttribute("newton:contactFrictionDamping"))  # from NewtonCollisionAPI
+        self.assertTrue(self.prim.HasAttribute("newton:contactFrictionStiffness"))  # from NewtonCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactAdhesion"))  # from NewtonCollisionAPI
         # SDF/hydro attrs should NOT be present on bare NewtonCollisionAPI
         self.assertFalse(self.prim.HasAttribute("newton:sdfMaxResolution"))
@@ -124,11 +124,11 @@ class TestNewtonCollisionAPI(unittest.TestCase):
             self.assertAlmostEqual(soft.GetMinimum(), 0.0)
             self.assertIsNone(soft.GetMaximum())
 
-    def test_contact_friction_damping(self):
-        self.assertFalse(self.prim.HasAttribute("newton:contactFrictionDamping"))
+    def test_contact_friction_stiffness(self):
+        self.assertFalse(self.prim.HasAttribute("newton:contactFrictionStiffness"))
 
         self.prim.ApplyAPI("NewtonCollisionAPI")
-        attr = self.prim.GetAttribute("newton:contactFrictionDamping")
+        attr = self.prim.GetAttribute("newton:contactFrictionStiffness")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), -math.inf)

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -32,6 +32,10 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         self.assertTrue(self.prim.HasAttribute("physics:collisionEnabled"))  # from PhysicsCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactMargin"))  # from NewtonCollisionAPI
         self.assertTrue(self.prim.HasAttribute("newton:contactGap"))  # from NewtonCollisionAPI
+        self.assertTrue(self.prim.HasAttribute("newton:contactStiffness"))  # from NewtonCollisionAPI
+        self.assertTrue(self.prim.HasAttribute("newton:contactDamping"))  # from NewtonCollisionAPI
+        self.assertTrue(self.prim.HasAttribute("newton:contactFrictionStiffness"))  # from NewtonCollisionAPI
+        self.assertTrue(self.prim.HasAttribute("newton:contactAdhesion"))  # from NewtonCollisionAPI
         # SDF/hydro attrs should NOT be present on bare NewtonCollisionAPI
         self.assertFalse(self.prim.HasAttribute("newton:sdfMaxResolution"))
         self.assertFalse(self.prim.HasAttribute("newton:hydroelasticStiffness"))
@@ -79,6 +83,86 @@ class TestNewtonCollisionAPI(unittest.TestCase):
             self.assertTrue(hard.IsValid())
             self.assertAlmostEqual(hard.GetMinimum(), 0.0)
             self.assertIsNone(hard.GetMaximum())
+
+    def test_contact_stiffness(self):
+        self.assertFalse(self.prim.HasAttribute("newton:contactStiffness"))
+
+        self.prim.ApplyAPI("NewtonCollisionAPI")
+        attr = self.prim.GetAttribute("newton:contactStiffness")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 2500.0)
+
+        success = attr.Set(5000.0)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 5000.0)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
+
+    def test_contact_damping(self):
+        self.assertFalse(self.prim.HasAttribute("newton:contactDamping"))
+
+        self.prim.ApplyAPI("NewtonCollisionAPI")
+        attr = self.prim.GetAttribute("newton:contactDamping")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 100.0)
+
+        success = attr.Set(200.0)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 200.0)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
+
+    def test_contact_friction_stiffness(self):
+        self.assertFalse(self.prim.HasAttribute("newton:contactFrictionStiffness"))
+
+        self.prim.ApplyAPI("NewtonCollisionAPI")
+        attr = self.prim.GetAttribute("newton:contactFrictionStiffness")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 1000.0)
+
+        success = attr.Set(2000.0)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 2000.0)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
+
+    def test_contact_adhesion(self):
+        self.assertFalse(self.prim.HasAttribute("newton:contactAdhesion"))
+
+        self.prim.ApplyAPI("NewtonCollisionAPI")
+        attr = self.prim.GetAttribute("newton:contactAdhesion")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 0.0)
+
+        success = attr.Set(0.05)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 0.05)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
 
 
 class TestNewtonSDFCollisionAPI(unittest.TestCase):

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -91,7 +91,7 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:contactStiffness")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertAlmostEqual(attr.Get(), 2500.0)
+        self.assertAlmostEqual(attr.Get(), -math.inf)
 
         success = attr.Set(5000.0)
         self.assertTrue(success)
@@ -111,7 +111,7 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:contactDamping")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertAlmostEqual(attr.Get(), 100.0)
+        self.assertAlmostEqual(attr.Get(), -math.inf)
 
         success = attr.Set(200.0)
         self.assertTrue(success)
@@ -131,7 +131,7 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:contactFrictionStiffness")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertAlmostEqual(attr.Get(), 1000.0)
+        self.assertAlmostEqual(attr.Get(), -math.inf)
 
         success = attr.Set(2000.0)
         self.assertTrue(success)
@@ -151,7 +151,7 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:contactAdhesion")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertAlmostEqual(attr.Get(), 0.0)
+        self.assertAlmostEqual(attr.Get(), -math.inf)
 
         success = attr.Set(0.05)
         self.assertTrue(success)


### PR DESCRIPTION
## Description

Add four per-shape contact model coefficients to `NewtonCollisionAPI`:

| Attribute | ShapeConfig | Type | Default | Units |
|---|---|---|---|---|
| `newton:contactStiffness` | `ke` | float | `-inf` | force / distance |
| `newton:contactDamping` | `kd` | float | `-inf` | force * time / distance |
| `newton:contactFrictionStiffness` | `kf` | float | `-inf` | force * time / distance |
| `newton:contactAdhesion` | `ka` | float | `-inf` | distance |

These are penalty-based contact model parameters that tune how the solver resolves contacts on a per-shape basis. Placement on `NewtonCollisionAPI` (rather than `NewtonMaterialAPI`) follows the physics-vs-numerics principle: these are solver tuning parameters, not physical material properties. Two shapes of the same material may need different stiffness values for numerical stability.

All four attributes use the `-inf` sentinel default (matching the `contactGap` precedent) so each engine can substitute its own builder default at parse time, rather than baking Newton's ShapeConfig values (`2500`, `100`, `1000`, `0`) into the shared schema. All four use soft minimum limits of `0`.

Along with #61 closes #25 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/newton-usd-schemas/blob/HEAD/CONTRIBUTING.md).