### PR TITLE
Add contact response attributes to NewtonMaterialAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 0.3.0b1
+# 0.3.0
 
 ## Features
 
+- Add contact response attributes (`contactStiffness`, `contactDamping`, `contactFrictionStiffness`, `contactAdhesion`) to `NewtonMaterialAPI` for describing how a material behaves on contact.
 - Added `NewtonSiteAPI`, which can be applied to Gprims to declare a non-colliding, massless reference shape used for sensing, attachment, or coordinate queries.
   - `NewtonSiteAPI` and `NewtonCollisionAPI` are mutually exclusive; sites cannot be colliders
 - Added `NewtonMassAPI`, which extends `PhysicsMassAPI`.

--- a/newton_usd_schemas/_version.py
+++ b/newton_usd_schemas/_version.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.3.0b1"
+__version__ = "0.3.0"

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -663,7 +663,7 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         Controls how rigid or compliant the material feels on contact. Higher values
         produce stiffer contacts at the cost of requiring smaller time steps.
 
-        If `newton:contactStiffness` is set to `-inf`, Newton's builder default should be used instead.
+        If `newton:contactStiffness` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force/distance"""
@@ -680,7 +680,7 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         Controls how much energy the material absorbs during contact. Higher values
         reduce bouncing.
 
-        If `newton:contactDamping` is set to `-inf`, Newton's builder default should be used instead.
+        If `newton:contactDamping` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force * time / distance"""
@@ -697,7 +697,7 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         At low sliding speeds, friction force equals `contactFrictionStiffness * velocity`
         (viscous regime); at high speeds it is clamped to the Coulomb limit `mu * normal_force`.
 
-        If `newton:contactFrictionStiffness` is set to `-inf`, Newton's builder default should be used instead.
+        If `newton:contactFrictionStiffness` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force * time / distance"""
@@ -714,7 +714,7 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         When two surfaces are within this distance, an attractive force pulls them together.
         A value of 0 or less disables adhesion.
 
-        If `newton:contactAdhesion` is set to `-inf`, Newton's builder default should be used instead.
+        If `newton:contactAdhesion` is set to `-inf`, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: distance"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -656,6 +656,74 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
             }
         }
     )
+
+    float newton:contactStiffness = -inf (
+        doc = """Normal stiffness of the contact response.
+
+        Controls how rigid or compliant the material feels on contact. Higher values
+        produce stiffer contacts at the cost of requiring smaller time steps.
+
+        If `newton:contactStiffness` is set to `-inf`, Newton's builder default should be used instead.
+
+        Range: [0, inf)
+        Units: force/distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
+
+    float newton:contactDamping = -inf (
+        doc = """Normal damping of the contact response.
+
+        Controls how much energy the material absorbs during contact. Higher values
+        reduce bouncing.
+
+        If `newton:contactDamping` is set to `-inf`, Newton's builder default should be used instead.
+
+        Range: [0, inf)
+        Units: force * time / distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
+
+    float newton:contactFrictionStiffness = -inf (
+        doc = """Stiffness of the tangential friction response.
+
+        At low sliding speeds, friction force equals `contactFrictionStiffness * velocity`
+        (viscous regime); at high speeds it is clamped to the Coulomb limit `mu * normal_force`.
+
+        If `newton:contactFrictionStiffness` is set to `-inf`, Newton's builder default should be used instead.
+
+        Range: [0, inf)
+        Units: force * time / distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
+
+    float newton:contactAdhesion = -inf (
+        doc = """Contact adhesion distance.
+
+        When two surfaces are within this distance, an attractive force pulls them together.
+        A value of 0 or less disables adhesion.
+
+        If `newton:contactAdhesion` is set to `-inf`, Newton's builder default should be used instead.
+
+        Range: [0, inf)
+        Units: distance"""
+        limits = {
+            dictionary soft = {
+                float minimum = 0
+            }
+        }
+    )
 }
 
 class NewtonMimicAPI "NewtonMimicAPI" (

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import unittest
 
 from pxr import Plug, Usd, UsdPhysics, UsdShade
@@ -30,6 +31,10 @@ class TestNewtonMaterialAPI(unittest.TestCase):
 
         self.assertTrue(self.material.HasAttribute("physics:dynamicFriction"))  # from PhysicsMaterialAPI
         self.assertTrue(self.material.HasAttribute("newton:torsionalFriction"))  # from NewtonMaterialAPI
+        self.assertTrue(self.material.HasAttribute("newton:contactStiffness"))  # from NewtonMaterialAPI
+        self.assertTrue(self.material.HasAttribute("newton:contactDamping"))  # from NewtonMaterialAPI
+        self.assertTrue(self.material.HasAttribute("newton:contactFrictionStiffness"))  # from NewtonMaterialAPI
+        self.assertTrue(self.material.HasAttribute("newton:contactAdhesion"))  # from NewtonMaterialAPI
 
     def test_api_limitations(self):
         prim: Usd.Prim = self.stage.DefinePrim("/NotMaterial", "Xform")
@@ -74,6 +79,86 @@ class TestNewtonMaterialAPI(unittest.TestCase):
             self.assertTrue(hard.IsValid())
             self.assertAlmostEqual(hard.GetMinimum(), 0.0)
             self.assertIsNone(hard.GetMaximum())
+
+    def test_contact_stiffness(self):
+        self.assertFalse(self.material.HasAttribute("newton:contactStiffness"))
+
+        self.material.ApplyAPI("NewtonMaterialAPI")
+        attr = self.material.GetAttribute("newton:contactStiffness")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), -math.inf)
+
+        success = attr.Set(5000.0)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 5000.0)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
+
+    def test_contact_damping(self):
+        self.assertFalse(self.material.HasAttribute("newton:contactDamping"))
+
+        self.material.ApplyAPI("NewtonMaterialAPI")
+        attr = self.material.GetAttribute("newton:contactDamping")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), -math.inf)
+
+        success = attr.Set(200.0)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 200.0)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
+
+    def test_contact_friction_stiffness(self):
+        self.assertFalse(self.material.HasAttribute("newton:contactFrictionStiffness"))
+
+        self.material.ApplyAPI("NewtonMaterialAPI")
+        attr = self.material.GetAttribute("newton:contactFrictionStiffness")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), -math.inf)
+
+        success = attr.Set(2000.0)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 2000.0)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
+
+    def test_contact_adhesion(self):
+        self.assertFalse(self.material.HasAttribute("newton:contactAdhesion"))
+
+        self.material.ApplyAPI("NewtonMaterialAPI")
+        attr = self.material.GetAttribute("newton:contactAdhesion")
+        self.assertIsNotNone(attr)
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), -math.inf)
+
+        success = attr.Set(0.05)
+        self.assertTrue(success)
+        self.assertTrue(attr.HasAuthoredValue())
+        self.assertAlmostEqual(attr.Get(), 0.05)
+
+        if USD_HAS_LIMITS:
+            soft = attr.GetSoftLimits()
+            self.assertTrue(soft.IsValid())
+            self.assertAlmostEqual(soft.GetMinimum(), 0.0)
+            self.assertIsNone(soft.GetMaximum())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Place the four contact response attributes (`contactStiffness`, `contactDamping`, `contactFrictionStiffness`, `contactAdhesion`) on `NewtonMaterialAPI` for describing how a material behaves on contact.

Material-level placement matches how contact behavior is authored in practice — in the MuJoCo menagerie, 45/50 models that author contact parameters do so via shared defaults inherited by many shapes. The four coefficients form a coherent tuning set alongside existing friction/restitution on `PhysicsMaterialAPI`. Per-shape override via `NewtonCollisionAPI` can be added later as a backward-compatible extension if needed.

This is an alternative to PR #62 (which placed these on `NewtonCollisionAPI`), based on WG discussion.

Uses `contactFrictionStiffness` for `kf` (not `contactFrictionDamping`), per SDD Section 5.4.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/newton-usd-schemas/blob/HEAD/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)