### PR TITLE
Try out None sentinals

### DIFF
--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -9,7 +9,7 @@ class NewtonSceneAPI "NewtonSceneAPI" (
     uniform int newton:maxSolverIterations = None (
         doc = """Maximum number of iterations of the physics solver.
 
-        If unset, the engine's default should be used instead.
+        If unset, each solver is free to choose an appropriate default.
 
         Range: [1, inf)
         Units: dimensionless"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -6,16 +6,16 @@ class NewtonSceneAPI "NewtonSceneAPI" (
     doc = "`NewtonSceneAPI` applies on top of a `PhysicsScene` prim, providing attributes to control a Newton solver."
 )
 {
-    uniform int newton:maxSolverIterations = -1 (
+    uniform int newton:maxSolverIterations = None (
         doc = """Maximum number of iterations of the physics solver.
 
-        If set to -1, each solver is free to choose an appropriate default.
+        If unset, the engine's default should be used instead.
 
-        Range: [-1, inf)
+        Range: [1, inf)
         Units: dimensionless"""
         limits = {
             dictionary hard = {
-                int minimum = -1
+                int minimum = 1
             }
         }
     )
@@ -450,7 +450,7 @@ class NewtonJointAPI "NewtonJointAPI" (
         }
     )
 
-    float newton:limitStiffness = -inf (
+    float newton:limitStiffness = None (
         doc = """Stiffness of the joint limit spring.
 
         When a DOF's position exceeds the range defined by the joint limits,
@@ -462,15 +462,15 @@ class NewtonJointAPI "NewtonJointAPI" (
         constraint (no spring). Note: some solvers may ignore this attribute
         and always enforce hard positional constraints.
 
-        A value of `-inf` means the engine's own default stiffness is used.
+        If unset, the engine's own default stiffness is used.
 
         The value is broadcast to all DOFs of the joint.
 
-        Range: [0, inf] when authored (sentinel `-inf` defers to engine default).
+        Range: [0, inf]
         Units: effort / degrees (angular DOFs) or effort / distance (linear DOFs)."""
     )
 
-    float newton:limitDamping = -inf (
+    float newton:limitDamping = None (
         doc = """Damping of the joint limit spring.
 
         When a DOF's position exceeds the range defined by the joint limits,
@@ -483,11 +483,11 @@ class NewtonJointAPI "NewtonJointAPI" (
         no spring to damp. Note: some solvers may ignore this attribute and
         always enforce hard positional constraints.
 
-        A value of `-inf` means the engine's own default damping is used.
+        If unset, the engine's own default damping is used.
 
         The value is broadcast to all DOFs of the joint.
 
-        Range: [0, inf) when authored (sentinel `-inf` defers to engine default).
+        Range: [0, inf)
         Units: effort * seconds / degrees (angular DOFs) or effort * seconds / distance (linear DOFs)."""
     )
 }
@@ -547,7 +547,7 @@ class NewtonMassAPI "NewtonMassAPI" (
         controlled by `newton:shellThickness`."""
     )
 
-    float newton:shellThickness = -inf (
+    float newton:shellThickness = None (
         doc = """Wall thickness for shell mass and inertia computation,
         measured inward from the outer surface of the shape.
 
@@ -556,7 +556,7 @@ class NewtonMassAPI "NewtonMassAPI" (
 
         Only used when `newton:massModel` is "shell"; ignored for "solid".
 
-        If set to `-inf`, the active solver chooses an appropriate thickness.
+        If unset, the active solver chooses an appropriate thickness.
         This is a per-solver decision: solvers may fall back to
         `newton:contactMargin`, use zero-thickness mathematical shell inertia,
         or apply their own default.
@@ -595,7 +595,7 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
             }
         }
     )
-    float newton:contactGap = -inf (
+    float newton:contactGap = None (
         doc = """Additional contact detection gap.
 
         AABBs are expanded by this value and potential contact points get added into the solver
@@ -603,7 +603,7 @@ class NewtonCollisionAPI "NewtonCollisionAPI" (
 
         Increasing `newton:contactGap` helps avoid tunneling by detecting contacts earlier.
 
-        If `newton:contactGap` is set to `-inf`, the engine's default should be used instead.
+        If `newton:contactGap` is unset, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: distance"""
@@ -622,18 +622,18 @@ class NewtonMeshCollisionAPI "NewtonMeshCollisionAPI" (
     By applying this schema, the prim also inherits the `PhysicsCollisionAPI`, `NewtonCollisionAPI` and `PhysicsMeshCollisionAPI` schemas."""
 )
 {
-    uniform int newton:maxHullVertices = -1 (
+    uniform int newton:maxHullVertices = None (
         doc = """Maximum number of vertices in the resulting convex hull approximation.
 
         This value is only relevant when `physics:approximation = "convexHull"`.
 
-        If `newton:maxHullVertices` is set to -1, the hull computation should use as many vertices as necessary to produce a perfect convex hull.
+        If unset, the hull computation should use as many vertices as necessary to produce a perfect convex hull.
 
-        Range: [-1, inf)
+        Range: [1, inf)
         Units: dimensionless"""
         limits = {
             dictionary hard = {
-                int minimum = -1
+                int minimum = 1
             }
         }
     )
@@ -667,13 +667,13 @@ class NewtonSDFCollisionAPI "NewtonSDFCollisionAPI" (
             }
         }
     )
-    uniform float newton:sdfTargetVoxelSize = -inf (
+    uniform float newton:sdfTargetVoxelSize = None (
         doc = """Target voxel size for the sparse SDF grid.
 
         When authored with a positive value, takes precedence over
         `newton:sdfMaxResolution`.
 
-        If `newton:sdfTargetVoxelSize` is set to `-inf`, `newton:sdfMaxResolution`
+        If `newton:sdfTargetVoxelSize` is unset, `newton:sdfMaxResolution`
         is used instead.
 
         Range: (0, inf)
@@ -714,13 +714,13 @@ class NewtonSDFCollisionAPI "NewtonSDFCollisionAPI" (
         (half the memory of `"float32"`). `"float32"` stores full-precision values.
         `"uint8"` uses 8-bit textures for minimum memory."""
     )
-    uniform float newton:sdfPadding = -inf (
+    uniform float newton:sdfPadding = None (
         doc = """SDF AABB padding.
 
         Enlarges the SDF's bounding box beyond the mesh AABB by this distance,
         extending the spatial domain in which distance queries are valid.
 
-        If `newton:sdfPadding` is set to `-inf`, the engine's default should be used instead.
+        If `newton:sdfPadding` is unset, the engine's default should be used instead.
 
         Range: (0, inf)
         Units: distance"""
@@ -796,13 +796,13 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         }
     )
 
-    float newton:contactStiffness = -inf (
+    float newton:contactStiffness = None (
         doc = """Normal stiffness of the contact response.
 
         Controls how rigid or compliant the material feels on contact. Higher values
         produce stiffer contacts at the cost of requiring smaller time steps.
 
-        If `newton:contactStiffness` is set to `-inf`, the engine's default should be used instead.
+        If `newton:contactStiffness` is unset, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force/distance"""
@@ -813,13 +813,13 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         }
     )
 
-    float newton:contactDamping = -inf (
+    float newton:contactDamping = None (
         doc = """Normal damping of the contact response.
 
         Controls how much energy the material absorbs during contact. Higher values
         reduce bouncing.
 
-        If `newton:contactDamping` is set to `-inf`, the engine's default should be used instead.
+        If `newton:contactDamping` is unset, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force * time / distance"""
@@ -830,14 +830,14 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         }
     )
 
-    float newton:contactFrictionGain = -inf (
+    float newton:contactFrictionGain = None (
         doc = """Gain of the tangential friction response.
 
         Friction force equals `contactFrictionGain * slip_velocity`, clamped to the
         Coulomb limit `mu * normal_force`. Larger values produce stronger resistance
         to small relative motion and more closely approximate ideal Coulomb sticking.
 
-        If `newton:contactFrictionGain` is set to `-inf`, the engine's default should be used instead.
+        If `newton:contactFrictionGain` is unset, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: force * time / distance"""
@@ -848,13 +848,13 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
         }
     )
 
-    float newton:contactAdhesion = -inf (
+    float newton:contactAdhesion = None (
         doc = """Contact adhesion distance.
 
         When two surfaces are within this distance, an attractive force pulls them together.
         A value of 0 or less disables adhesion.
 
-        If `newton:contactAdhesion` is set to `-inf`, the engine's default should be used instead.
+        If `newton:contactAdhesion` is unset, the engine's default should be used instead.
 
         Range: [0, inf)
         Units: distance"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -1110,8 +1110,6 @@ class NewtonPIDControlAPI "NewtonPIDControlAPI" (
         The accumulated integral is clamped to [-integralMax, +integralMax]
         to prevent integral windup under sustained tracking error, such as during actuator saturation.
 
-        A value of `inf` means no anti-windup clamping is applied.
-
         Range: [0, inf)
         Units: distance * seconds or radians * seconds"""
         limits = {
@@ -1164,7 +1162,6 @@ class NewtonMaxEffortClampingAPI "NewtonMaxEffortClampingAPI" (
         doc = """Maximum output effort limit (in joint space).
 
         The actuator output is clamped to the range [-maxEffort, +maxEffort].
-        A value of `inf` means no effort clamping is applied.
 
         Range: [0, inf)
         Units: force or torque"""
@@ -1194,7 +1191,6 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
         doc = """Effort limit for the effort-speed curve (in joint space).
 
         Caps the velocity-dependent effort envelope.
-        A value of `inf` means no motor effort capping is applied.
 
         Range: [0, inf)
         Units: force or torque"""
@@ -1210,7 +1206,6 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
 
         This is the maximum effort the motor can produce when not spinning,
         before being capped by `maxMotorEffort`.
-        A value of `inf` means the motor is not effort-limited at stall.
 
         Range: [0, inf)
         Units: force or torque"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -1104,15 +1104,15 @@ class NewtonPIDControlAPI "NewtonPIDControlAPI" (
         }
     )
 
-    float newton:integralMax = None (
+    float newton:integralMax = inf (
         doc = """Anti-windup limit for the integral term.
 
         The accumulated integral is clamped to [-integralMax, +integralMax]
         to prevent integral windup under sustained tracking error, such as during actuator saturation.
 
-        If unset, no anti-windup clamping is applied.
+        A value of `inf` means no anti-windup clamping is applied.
 
-        Range: (0, inf)
+        Range: [0, inf)
         Units: distance * seconds or radians * seconds"""
         limits = {
             dictionary hard = {
@@ -1160,13 +1160,13 @@ class NewtonMaxEffortClampingAPI "NewtonMaxEffortClampingAPI" (
     """
 )
 {
-    float newton:maxEffort = None (
+    float newton:maxEffort = inf (
         doc = """Maximum output effort limit (in joint space).
 
         The actuator output is clamped to the range [-maxEffort, +maxEffort].
-        If unset, no effort clamping is applied.
+        A value of `inf` means no effort clamping is applied.
 
-        Range: (0, inf)
+        Range: [0, inf)
         Units: force or torque"""
         limits = {
             dictionary hard = {
@@ -1190,13 +1190,13 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
     """
 )
 {
-    float newton:maxMotorEffort = None (
+    float newton:maxMotorEffort = inf (
         doc = """Effort limit for the effort-speed curve (in joint space).
 
         Caps the velocity-dependent effort envelope.
-        If unset, no motor effort capping is applied.
+        A value of `inf` means no motor effort capping is applied.
 
-        Range: (0, inf)
+        Range: [0, inf)
         Units: force or torque"""
         limits = {
             dictionary hard = {
@@ -1205,14 +1205,14 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
         }
     )
 
-    float newton:saturationEffort = None (
+    float newton:saturationEffort = inf (
         doc = """Peak motor effort at stall (zero velocity).
 
         This is the maximum effort the motor can produce when not spinning,
         before being capped by `maxMotorEffort`.
-        If unset, the motor is not effort-limited at stall.
+        A value of `inf` means the motor is not effort-limited at stall.
 
-        Range: (0, inf)
+        Range: [0, inf)
         Units: force or torque"""
         limits = {
             dictionary hard = {
@@ -1221,12 +1221,12 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
         }
     )
 
-    float newton:velocityLimit = None (
+    float newton:velocityLimit = inf (
         doc = """Maximum no-load joint velocity for the effort-speed curve.
 
         At this velocity, the motor can produce zero effort in the direction
-        of motion due to losses such as back-EMF. If unset, the effort-speed
-        saturation effect is disabled.
+        of motion due to losses such as back-EMF. A value of `inf` disables the effort-speed
+        saturation effect.
 
         Range: (0, inf)
         Units: distance / seconds or radians / seconds"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -432,12 +432,12 @@ class NewtonJointAPI "NewtonJointAPI" (
         }
     )
 
-    float newton:velocityLimit = inf (
+    float newton:velocityLimit = None (
         doc = """Maximum allowable DOF velocity.
 
         The solver clamps each DOF's velocity to the range
         `[-velocityLimit, +velocityLimit]` at every time step.
-        A value of `inf` means no velocity clamping is applied.
+        If unset, no velocity clamping is applied.
 
         The value is broadcast to all DOFs of the joint.
 
@@ -1104,13 +1104,15 @@ class NewtonPIDControlAPI "NewtonPIDControlAPI" (
         }
     )
 
-    float newton:integralMax = inf (
+    float newton:integralMax = None (
         doc = """Anti-windup limit for the integral term.
 
         The accumulated integral is clamped to [-integralMax, +integralMax]
         to prevent integral windup under sustained tracking error, such as during actuator saturation.
 
-        Range: [0, inf)
+        If unset, no anti-windup clamping is applied.
+
+        Range: (0, inf)
         Units: distance * seconds or radians * seconds"""
         limits = {
             dictionary hard = {
@@ -1158,12 +1160,13 @@ class NewtonMaxEffortClampingAPI "NewtonMaxEffortClampingAPI" (
     """
 )
 {
-    float newton:maxEffort = inf (
+    float newton:maxEffort = None (
         doc = """Maximum output effort limit (in joint space).
 
         The actuator output is clamped to the range [-maxEffort, +maxEffort].
+        If unset, no effort clamping is applied.
 
-        Range: [0, inf)
+        Range: (0, inf)
         Units: force or torque"""
         limits = {
             dictionary hard = {
@@ -1187,12 +1190,13 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
     """
 )
 {
-    float newton:maxMotorEffort = inf (
+    float newton:maxMotorEffort = None (
         doc = """Effort limit for the effort-speed curve (in joint space).
 
         Caps the velocity-dependent effort envelope.
+        If unset, no motor effort capping is applied.
 
-        Range: [0, inf)
+        Range: (0, inf)
         Units: force or torque"""
         limits = {
             dictionary hard = {
@@ -1201,13 +1205,14 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
         }
     )
 
-    float newton:saturationEffort = inf (
+    float newton:saturationEffort = None (
         doc = """Peak motor effort at stall (zero velocity).
 
         This is the maximum effort the motor can produce when not spinning,
         before being capped by `maxMotorEffort`.
+        If unset, the motor is not effort-limited at stall.
 
-        Range: [0, inf)
+        Range: (0, inf)
         Units: force or torque"""
         limits = {
             dictionary hard = {
@@ -1216,12 +1221,12 @@ class NewtonDCMotorClampingAPI "NewtonDCMotorClampingAPI" (
         }
     )
 
-    float newton:velocityLimit = inf (
+    float newton:velocityLimit = None (
         doc = """Maximum no-load joint velocity for the effort-speed curve.
 
         At this velocity, the motor can produce zero effort in the direction
-        of motion due to losses such as back-EMF. A value of inf disables the effort-speed
-        saturation effect.
+        of motion due to losses such as back-EMF. If unset, the effort-speed
+        saturation effect is disabled.
 
         Range: (0, inf)
         Units: distance / seconds or radians / seconds"""

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import unittest
 
 from pxr import Plug, Sdf, Usd
@@ -225,14 +226,10 @@ class TestNewtonPIDControlAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonPIDControlAPI")
         attr = self.prim.GetAttribute("newton:integralMax")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertIsNone(attr.Get())
+        self.assertEqual(attr.Get(), math.inf)
 
         attr.Set(100.0)
         self.assertAlmostEqual(attr.Get(), 100.0)
-
-        # Block resets to None
-        attr.Block()
-        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -319,15 +316,11 @@ class TestNewtonMaxEffortClampingAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:maxEffort")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertIsNone(attr.Get())
+        self.assertEqual(attr.Get(), math.inf)
 
         attr.Set(100.0)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 100.0)
-
-        # Block resets to None
-        attr.Block()
-        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -366,14 +359,10 @@ class TestNewtonDCMotorClampingAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonDCMotorClampingAPI")
         attr = self.prim.GetAttribute("newton:maxMotorEffort")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertIsNone(attr.Get())
+        self.assertEqual(attr.Get(), math.inf)
 
         attr.Set(100.0)
         self.assertAlmostEqual(attr.Get(), 100.0)
-
-        # Block resets to None
-        attr.Block()
-        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -385,14 +374,10 @@ class TestNewtonDCMotorClampingAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonDCMotorClampingAPI")
         attr = self.prim.GetAttribute("newton:saturationEffort")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertIsNone(attr.Get())
+        self.assertEqual(attr.Get(), math.inf)
 
         attr.Set(10.0)
         self.assertAlmostEqual(attr.Get(), 10.0)
-
-        # Block resets to None
-        attr.Block()
-        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -404,15 +389,11 @@ class TestNewtonDCMotorClampingAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonDCMotorClampingAPI")
         attr = self.prim.GetAttribute("newton:velocityLimit")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertIsNone(attr.Get())
+        self.assertEqual(attr.Get(), math.inf)
 
         attr.Set(30.0)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 30.0)
-
-        # Block resets to None
-        attr.Block()
-        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -226,10 +226,14 @@ class TestNewtonPIDControlAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonPIDControlAPI")
         attr = self.prim.GetAttribute("newton:integralMax")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), math.inf)
+        self.assertIsNone(attr.Get())
 
         attr.Set(100.0)
         self.assertAlmostEqual(attr.Get(), 100.0)
+
+        # Block resets to None
+        attr.Block()
+        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -316,11 +320,15 @@ class TestNewtonMaxEffortClampingAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:maxEffort")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), math.inf)
+        self.assertIsNone(attr.Get())
 
         attr.Set(100.0)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 100.0)
+
+        # Block resets to None
+        attr.Block()
+        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -359,10 +367,14 @@ class TestNewtonDCMotorClampingAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonDCMotorClampingAPI")
         attr = self.prim.GetAttribute("newton:maxMotorEffort")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), math.inf)
+        self.assertIsNone(attr.Get())
 
         attr.Set(100.0)
         self.assertAlmostEqual(attr.Get(), 100.0)
+
+        # Block resets to None
+        attr.Block()
+        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -374,10 +386,14 @@ class TestNewtonDCMotorClampingAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonDCMotorClampingAPI")
         attr = self.prim.GetAttribute("newton:saturationEffort")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), math.inf)
+        self.assertIsNone(attr.Get())
 
         attr.Set(10.0)
         self.assertAlmostEqual(attr.Get(), 10.0)
+
+        # Block resets to None
+        attr.Block()
+        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -389,11 +405,15 @@ class TestNewtonDCMotorClampingAPI(unittest.TestCase):
         self.prim.ApplyAPI("NewtonDCMotorClampingAPI")
         attr = self.prim.GetAttribute("newton:velocityLimit")
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), math.inf)
+        self.assertIsNone(attr.Get())
 
         attr.Set(30.0)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 30.0)
+
+        # Block resets to None
+        attr.Block()
+        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import unittest
 
 from pxr import Plug, Sdf, Usd

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import unittest
 
 from pxr import Plug, Usd, UsdGeom
@@ -67,12 +66,16 @@ class TestNewtonCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:contactGap")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(0.1)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 0.1)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -140,11 +143,15 @@ class TestNewtonSDFCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:sdfTargetVoxelSize")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         attr.Set(0.005)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 0.005)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -202,11 +209,15 @@ class TestNewtonSDFCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:sdfPadding")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         attr.Set(0.05)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 0.05)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
@@ -281,29 +292,21 @@ class TestNewtonMeshCollisionAPI(unittest.TestCase):
         attr = self.prim.GetAttribute("newton:maxHullVertices")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -1)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(100)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertEqual(attr.Get(), 100)
 
-        # Test rounding down to the nearest integer
-        success = attr.Set(0.9)
-        self.assertTrue(success)
-        self.assertTrue(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), 0)
-
-        # Test setting to -1
-        success = attr.Set(-1)
-        self.assertTrue(success)
-        self.assertTrue(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -1)
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
             self.assertTrue(hard.IsValid())
-            self.assertEqual(hard.GetMinimum(), -1)
+            self.assertEqual(hard.GetMinimum(), 1)
             self.assertIsNone(hard.GetMaximum())
 
 

--- a/tests/test_joint.py
+++ b/tests/test_joint.py
@@ -115,12 +115,16 @@ class TestNewtonJointAPI(unittest.TestCase):
         attr = self.revolute.GetAttribute("newton:velocityLimit")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), math.inf)
+        self.assertIsNone(attr.Get())
 
         success = attr.Set(360.0)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 360.0)
+
+        # Block resets to None
+        attr.Block()
+        self.assertIsNone(attr.Get())
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()

--- a/tests/test_joint.py
+++ b/tests/test_joint.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import unittest
 
 from pxr import Plug, Usd, UsdPhysics

--- a/tests/test_joint.py
+++ b/tests/test_joint.py
@@ -133,24 +133,32 @@ class TestNewtonJointAPI(unittest.TestCase):
         attr = self.revolute.GetAttribute("newton:limitStiffness")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(174.5)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 174.5)
 
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
+
     def test_limit_damping(self):
         self.revolute.ApplyAPI("NewtonJointAPI")
         attr = self.revolute.GetAttribute("newton:limitDamping")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(0.1745)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 0.1745)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
 
 if __name__ == "__main__":

--- a/tests/test_mass.py
+++ b/tests/test_mass.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import unittest
 
 from pxr import Plug, Usd, UsdGeom, Vt
@@ -74,12 +73,18 @@ class TestNewtonMassAPI(unittest.TestCase):
         attr = self.shape_prim.GetAttribute("newton:shellThickness")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(0.002)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 0.002)
+
+        # to set the default/fallback, we must block instead of Set(None)
+        # which means there will be no authored value
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import unittest
 
 from pxr import Plug, Usd, UsdPhysics, UsdShade
@@ -87,12 +86,16 @@ class TestNewtonMaterialAPI(unittest.TestCase):
         attr = self.material.GetAttribute("newton:contactStiffness")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(5000.0)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 5000.0)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             soft = attr.GetSoftLimits()
@@ -107,12 +110,16 @@ class TestNewtonMaterialAPI(unittest.TestCase):
         attr = self.material.GetAttribute("newton:contactDamping")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(200.0)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 200.0)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             soft = attr.GetSoftLimits()
@@ -120,19 +127,23 @@ class TestNewtonMaterialAPI(unittest.TestCase):
             self.assertAlmostEqual(soft.GetMinimum(), 0.0)
             self.assertIsNone(soft.GetMaximum())
 
-    def test_contact_friction_stiffness(self):
+    def test_contact_friction_gain(self):
         self.assertFalse(self.material.HasAttribute("newton:contactFrictionGain"))
 
         self.material.ApplyAPI("NewtonMaterialAPI")
         attr = self.material.GetAttribute("newton:contactFrictionGain")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(2000.0)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 2000.0)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             soft = attr.GetSoftLimits()
@@ -147,12 +158,16 @@ class TestNewtonMaterialAPI(unittest.TestCase):
         attr = self.material.GetAttribute("newton:contactAdhesion")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -math.inf)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(0.05)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertAlmostEqual(attr.Get(), 0.05)
+
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
 
         if USD_HAS_LIMITS:
             soft = attr.GetSoftLimits()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -36,17 +36,21 @@ class TestNewtonSceneAPI(unittest.TestCase):
         attr = self.scene.GetAttribute("newton:maxSolverIterations")
         self.assertIsNotNone(attr)
         self.assertFalse(attr.HasAuthoredValue())
-        self.assertEqual(attr.Get(), -1)
+        self.assertEqual(attr.Get(), None)
 
         success = attr.Set(10)
         self.assertTrue(success)
         self.assertTrue(attr.HasAuthoredValue())
         self.assertEqual(attr.Get(), 10)
 
+        attr.Block()
+        self.assertFalse(attr.HasAuthoredValue())
+        self.assertEqual(attr.Get(), None)
+
         if USD_HAS_LIMITS:
             hard = attr.GetHardLimits()
             self.assertTrue(hard.IsValid())
-            self.assertEqual(hard.GetMinimum(), -1)
+            self.assertEqual(hard.GetMinimum(), 1)
             self.assertIsNone(hard.GetMaximum())
 
     def test_time_steps_per_second(self):


### PR DESCRIPTION
## Description

Replace sentinel defaults (`-inf`, `-1`) with `None` (no fallback) for schema attributes where "unset" means "solver/engine picks its own default."

### Motivation

UsdPhysics established a pattern of using out-of-range constants as sentinels — e.g. `physics:centerOfMass = (-inf, -inf, -inf)` means "compute from geometry." Newton schemas inherited this pattern:

```usda
float newton:limitStiffness = -inf    # "engine picks its default"
uniform int newton:maxSolverIterations = -1  # "solver picks its default"
```

These sentinels create problems:
- **Awkward ranges:** "Range: [-1, inf)" — is -1 a valid iteration count? No.
- **Consumer burden:** must special-case these values before doing math
- **Not self-documenting:** schema doesn't indicate which values are magic vs real

### Solution

Declare these attributes with `= None` (no fallback value). When no opinion exists, `attr.Get()` returns `None`:

```usda
float newton:limitStiffness = None (
    doc = "If unset, the engine's own default stiffness is used."
)
```

This gives us:
- **Clean ranges:** `[0, inf]` — every expressible value is valid
- **Simple unset check:** `attr.Get() is None`
- **Self-documenting:** `None` clearly means "not authored"

### Where we draw the line

We do NOT replace defaults where `inf` flows directly into math and produces correct behavior:

```usda
float newton:integralMax = inf    # clamp(x, -inf, inf) = unbounded range
float newton:maxEffort = inf      # clamp(effort, -inf, inf) = no effort cap
```

Here `inf` is the real intended value (unbounded clamp range), not a sentinel.

**Decision rule:**
- `inf` meaning "use the builder/solver default" where the importer immediately replaces it → sentinel → `None` (e.g. joint `velocityLimit`: importer converts `inf` → builder default of 1e6)
- `-inf` or `-1` meaning "I haven't chosen, engine/solver pick for me" → sentinel → `None`
- `inf` in `clamp(x, -val, val)` where unbounded IS the physics → real value → keep `inf`

### Why explicit `= None` over omitting the fallback entirely

A schema attribute with no `= <value>` declaration at all also returns `None` from `Get()`:

```usda
float newton:limitStiffness (
    doc = "If unset, the engine's own default stiffness is used."
)
```

This is legal and has the same runtime behavior. We prefer the explicit `= None` because:
- **Communicates intent:** tells schema readers that the unset state is deliberate and meaningful, not an oversight or a forgotten default
- **Distinguishes from "TODO":** an attr with no default could mean "we haven't decided yet" — `= None` says "we decided: unset is the correct default state"
- **Grep-friendly:** you can search the schema for `= None` to find all attrs with this pattern

Both approaches produce identical runtime behavior (`attr.Get() is None` when unauthored). The difference is purely communicative — `= None` makes the design decision visible in the schema source.
### Ergonomic tradeoff

To reset an authored attr back to unset, users call `attr.Block()` or `attr.Clear()` — `attr.Set(None)` is not valid for typed attributes. We think this is acceptable vs sentinel values polluting valid ranges.

### Attrs converted to None (13)

| Attr | Was | API |
|------|-----|-----|
| `newton:maxSolverIterations` | `-1` | NewtonSceneAPI |
| `newton:velocityLimit` | `inf` | NewtonJointAPI |
| `newton:limitStiffness` | `-inf` | NewtonJointAPI |
| `newton:limitDamping` | `-inf` | NewtonJointAPI |
| `newton:shellThickness` | `-inf` | NewtonCollisionAPI |
| `newton:contactGap` | `-inf` | NewtonCollisionAPI |
| `newton:maxHullVertices` | `-1` | NewtonCollisionAPI |
| `newton:sdfTargetVoxelSize` | `-inf` | NewtonCollisionAPI |
| `newton:sdfPadding` | `-inf` | NewtonCollisionAPI |
| `newton:contactStiffness` | `-inf` | NewtonMaterialAPI |
| `newton:contactDamping` | `-inf` | NewtonMaterialAPI |
| `newton:contactFrictionGain` | `-inf` | NewtonMaterialAPI |
| `newton:contactAdhesion` | `-inf` | NewtonMaterialAPI |

### Attrs kept as inf (5 actuator attrs)

| Attr | Reason |
|------|--------|
| `newton:integralMax` | `clamp(integral, -inf, inf)` = unbounded |
| `newton:maxEffort` | `clamp(effort, -inf, inf)` = unbounded |
| `newton:maxMotorEffort` | Caps effort-speed envelope |
| `newton:saturationEffort` | Stall torque limit |
| `newton:velocityLimit` (DC motor) | `vel/inf = 0` = no speed dropoff |

### Precedent in upstream USD schemas

Surveyed all Pixar USD domain schemas for sentinel and no-fallback patterns:

**Sentinel defaults (`-inf`, `-1`):**
- **UsdPhysics**: `centerOfMass = (-inf,-inf,-inf)` (compute from geometry), `gravityMagnitude = -inf` (use 9.81), `lowerLimit = -inf` (no limit)
- **UsdLux**: `shadow:distance = -1` (no max distance), `shadow:falloff = -1` (no falloff)

**Real `inf` values (not sentinels):**
- **UsdPhysics**: `breakForce = inf` (unbreakable), `breakTorque = inf`, `drive:maxForce = inf` (unlimited)

**No-fallback pattern (attr declared without any default):**
- **UsdGeom**: `uOrder`, `vOrder` on NurbsPatch — semantics are "must be authored" (no sensible default)
- **UsdVol**: `fieldIndex` — optional, no default

**`= None` pattern:** not used in any upstream Pixar schema. We would be the first.

### Open question for AOUSD

Is there a semantic difference between `= None` and simply omitting the fallback in a schema definition? Both produce identical runtime behavior (`attr.Get() is None`). The existing no-fallback pattern in UsdGeom/UsdVol means "must author" — we want to express something different: "unset is a valid, deliberate state meaning the engine picks its own default." The explicit `= None` communicates this intent at the schema source level.

- Is this distinction recognized by USD tooling, or is it purely a source-level convention?
- Do USD-aware UIs handle None-default attrs gracefully (blank widget vs error state)?
- Would AOUSD WGs consider `= None` as an alternative to sentinel values for future schema attrs?

## Checklist

- [x] Schema changes in `generatedSchema.usda`
- [x] Tests updated (Block/clear tests for all None attrs)
- [x] Linter passing
- [x] AOUSD forum post: https://forum.aousd.org/t/replacing-sentinel-fallback-values-with-none-in-schema-definitions/2973
