### PR TITLE
Document that mimic leader and follower share a joint type

### DIFF
--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -872,6 +872,10 @@ class NewtonMimicAPI "NewtonMimicAPI" (
     A mimic constraint enforces that `joint0 = coef0 + coef1 * joint1` for the joint DOFs,
     where `joint0` is this joint (the follower) and `joint1` (the leader) is specified via the `newton:mimicJoint` relationship.
 
+    The leader and follower must be the same joint type. The coefficients are expressed in the follower's
+    position units, so mimicking across types -- an angular follower tracking a linear leader, or the reverse --
+    has no well defined units and is not supported.
+
     The behavior on multi-DOF joints is undefined. The mimic constraint will be applied to each DOF independently,
     but as the coefficients are shared across all DOFs, the units for translational and rotational DOFs will be mixed.
     Therefore, it is recommended to only use this API on single-DOF joints.
@@ -885,7 +889,9 @@ class NewtonMimicAPI "NewtonMimicAPI" (
     )
 
     rel newton:mimicJoint (
-        doc = "Joint that will be mimicked."
+        doc = """Joint that will be mimicked.
+
+        Must be the same joint type as the joint this API is applied to."""
     )
 
     float newton:mimicCoef0 = 0.0 (


### PR DESCRIPTION
## Description

Document that `NewtonMimicAPI` requires the leader and follower to be the same joint type.

The coefficients are expressed in the follower's position units — `newton:mimicCoef0` is "distance or degrees (matches the joint type for single-DOF joints)" and `newton:mimicCoef1` is "dimensionless". Both of those hold only when the two joints share a type: a hinge follower mimicking a slide leader would give `coef1` units of degrees per distance, and the existing wording does not cover that case.

The restriction was assumed by implementations but never stated, which came up while fixing the `newton:mimicCoef0` unit conversion in the MuJoCo and URDF converters and in Newton's importer (newton-physics/mujoco-usd-converter#107, newton-physics/urdf-usd-converter#133). Rather than define units for the mixed case, this states it is unsupported, which is what those implementations assume.

Also expands `newton:mimicJoint`, previously a bare "Joint that will be mimicked.", with the same requirement.

Documentation only — no schema attributes, defaults, or generated code change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/newton-usd-schemas/blob/HEAD/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
