### PR TITLE
Document contact friction coefficients as length-dimensioned

### DIFF
--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -1001,9 +1001,8 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
     float newton:torsionalFriction = 0.005 (
         doc = """Torsional friction coefficient (resistance to spinning at a contact point).
 
-        Length-dimensioned rather than dimensionless: the coefficient scales a normal
-        force into a torsional one, and can be interpreted as the diameter of the
-        contact patch. It therefore scales with the stage's `metersPerUnit`.
+        Scales the normal force into a torsional one, and can be interpreted as the
+        diameter of the contact patch. Higher values more strongly resist spinning.
 
         Range: [0, inf)
         Units: distance"""
@@ -1017,9 +1016,9 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
     float newton:rollingFriction = 0.0001 (
         doc = """Rolling friction coefficient (resistance to rolling motion).
 
-        Length-dimensioned, on the same basis as `newton:torsionalFriction`; it can be
-        interpreted as the depth of the local deformation over which energy is
-        dissipated, and likewise scales with the stage's `metersPerUnit`.
+        Scales the normal force into a rolling one, and can be interpreted as the depth
+        of the local deformation within which energy is dissipated. Higher values more
+        strongly resist rolling.
 
         Range: [0, inf)
         Units: distance"""

--- a/newton_usd_schemas/generatedSchema.usda
+++ b/newton_usd_schemas/generatedSchema.usda
@@ -1001,8 +1001,12 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
     float newton:torsionalFriction = 0.005 (
         doc = """Torsional friction coefficient (resistance to spinning at a contact point).
 
+        Length-dimensioned rather than dimensionless: the coefficient scales a normal
+        force into a torsional one, and can be interpreted as the diameter of the
+        contact patch. It therefore scales with the stage's `metersPerUnit`.
+
         Range: [0, inf)
-        Units: dimensionless"""
+        Units: distance"""
         limits = {
             dictionary hard = {
                 float minimum = 0
@@ -1013,8 +1017,12 @@ class NewtonMaterialAPI "NewtonMaterialAPI" (
     float newton:rollingFriction = 0.0001 (
         doc = """Rolling friction coefficient (resistance to rolling motion).
 
+        Length-dimensioned, on the same basis as `newton:torsionalFriction`; it can be
+        interpreted as the depth of the local deformation over which energy is
+        dissipated, and likewise scales with the stage's `metersPerUnit`.
+
         Range: [0, inf)
-        Units: dimensionless"""
+        Units: distance"""
         limits = {
             dictionary hard = {
                 float minimum = 0


### PR DESCRIPTION
## Description

`newton:torsionalFriction` and `newton:rollingFriction` on `NewtonMaterialAPI` are documented as `Units: dimensionless`. Both are length-dimensioned, and every consumer of them agrees:

- Newton's `SolverXPBD` clamps an **angular** impulse to `lambda_n * mu`, where `lambda_n` is the normal **linear** impulse. Torque = force x length, so `mu` must carry a length.
- Newton's `SolverMuJoCo` writes both straight into MuJoCo's `geom_friction` as `vec3f(mu, torsional, rolling)`, and MuJoCo [documents both slots](https://mujoco.readthedocs.io/en/stable/computation/index.html) as having "units of length" — "the diameter of the surface contact patch" and "the depth of the local deformation within which energy is dissipated".
- The declared defaults, 0.005 and 0.0001, are MuJoCo's own `friction="1 0.005 0.0001"` values. Carrying them across is only coherent if they denote the same quantity.

(Newton's `SolverKamino` does not implement either coefficient yet, so it neither confirms nor contradicts.)

This is a documentation correction only — no attribute names, types, defaults or limits change, so it is not a schema-compatibility break. `python -m unittest discover -s ./tests` passes, 195 tests.

The distinction is not academic: a length-dimensioned coefficient has to scale with the stage's `metersPerUnit` while a dimensionless one must not, so a centimetre-authored stage is silently wrong under one reading or the other. `Units: distance` carries that on its own, as it does for the other distance-valued attributes here, so the doc text just describes what each coefficient does.

Related: [newton-physics/newton#3892](https://github.com/newton-physics/newton/pull/3892) corrects Newton's own docstrings for the same two quantities and fixes its USD import fallbacks, which had drifted from the values this schema defines. That PR aligns with this schema's *values* and stands on its own; this one fixes the prose those values were described by.

Also related: [google-deepmind/mujoco#3472](https://github.com/google-deepmind/mujoco/issues/3472), where MuJoCo's adoption of v0.4.0 has separate unit and semantic issues. MuJoCo's 1:1 mapping of these two friction coefficients is *correct*, which is part of the evidence above.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/newton-usd-schemas/blob/HEAD/CONTRIBUTING.md).
