### PR TITLE
Fix PyPI publish for Metadata-Version 2.5 and align action pins with newton

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867  # v7.1.6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       with:
         enable-cache: ${{ inputs.enable-uv-cache }}
         cache-dependency-glob: ${{ inputs.cache-dependency-glob }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
@@ -41,7 +41,7 @@ jobs:
         run: uv build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: newton-usd-schemas-dist-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
           path: dist/
@@ -59,7 +59,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
@@ -67,7 +67,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: newton-usd-schemas-dist-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
           path: dist/
@@ -76,7 +76,7 @@ jobs:
         run: uv run --group dev poe test-ci
 
       - name: Upload report artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: newton-usd-schemas-coverage-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
           include-hidden-files: true
@@ -92,7 +92,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
         with:
           files: ${{ github.workspace }}/.coverage.xml
           flags: unittests
@@ -111,7 +111,7 @@ jobs:
       id-token: write
     steps:
       - name: Download wheel and source tarball
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: newton-usd-schemas-dist-${{ github.ref_name }}
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,4 +116,4 @@ jobs:
           name: newton-usd-schemas-dist-${{ github.ref_name }}
           path: dist/
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2


### PR DESCRIPTION
Fixes the v0.5.0 deploy failure in [run 31741873420](https://github.com/newton-physics/newton-usd-schemas/actions/runs/31741873420/job/94588484229), and brings the rest of the action pins in line with [newton](https://github.com/newton-physics/newton).

## The deploy failure

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

[hatchling 1.32.0](https://pypi.org/project/hatchling/1.32.0/) (released 2026-08-11) changed [`DEFAULT_METADATA_VERSION`](https://github.com/pypa/hatch/blob/hatchling-v1.32.0/backend/src/hatchling/metadata/spec.py#L12) from `2.4` to `2.5`, so `uv build` now stamps `Metadata-Version: 2.5` on both the wheel and the sdist. The publish action was pinned to v1.12.4, whose bundled `twine 6.1.0` / `packaging 24.2` predate 2.5 — `packaging`'s `_VALID_METADATA_VERSIONS` stops at `2.4`, so twine's pre-upload check rejects the artifacts before any network call. v1.14.2 ships `twine 7.0.0` / `packaging 26.2`, which accept 2.5; [its release notes call this out explicitly](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2). PyPI's own [`SUPPORTED_METADATA_VERSIONS`](https://github.com/pypi/warehouse/blob/main/warehouse/forklift/metadata.py#L26) already includes 2.5, so the upload itself would have been accepted.

Verified by running each candidate toolchain against the actual v0.5.0 artifacts from that run:

```
twine 6.1.0 + packaging 24.2  (v1.12.4, was pinned)  -> ERROR: '2.5' is not a valid metadata version
twine 6.1.0 + packaging 25.0  (v1.13.0, newton's)    -> ERROR: '2.5' is not a valid metadata version
twine 7.0.0 + packaging 26.2  (v1.14.2, this PR)     -> PASSED (wheel and sdist)
```

This is the one pin deliberately **ahead** of newton: newton is on v1.13.0, which does not carry the twine 7 update and would not fix this.

## Aligning the rest

| action | before | after (newton's SHA) |
| --- | --- | --- |
| `actions/checkout` | v4.3.1 | v6.0.1 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `actions/download-artifact` | v4.3.0 | v8.0.1 |
| `codecov/codecov-action` | v5.5.2 | v5.5.3 |
| `astral-sh/setup-uv` | v7.1.6 | v7.6.0 |

`codecov/test-results-action` stays at v1.2.1 — already the latest release, and newton does not use it.

The artifact actions cross several majors, so the relevant breaking changes: `download-artifact` v5 changed single-artifact-by-ID path behavior (this repo downloads by `name`, so it is unaffected), v7 requires runner ≥ 2.327.1, and v8 defaults `digest-mismatch` to `error` and skips decompressing non-zip content. `upload-artifact` v6 also requires runner ≥ 2.327.1. All jobs here run on GitHub-hosted runners. Upload and download move together in the same commit, which matters because `build` uploads the dist that both `test` and `deploy` consume. Every input this workflow passes (`name`, `path`, `include-hidden-files`) still exists in v7/v8, and all three actions are now `node24`, which also clears the Node 20 deprecation annotation on the deploy job.

The `test` matrix exercises the upload/download handoff on every OS, so it covers the artifact bump. All 17 checks pass on this branch (build, lint, and test across macos / ubuntu / ubuntu-24.04-arm / windows on Python 3.10-3.13); `deploy` is tag-gated and skips, so that path cannot be exercised until a release.

Note the `deploy` job is gated on `refs/tags/*` and a re-run replays the workflow from the tagged commit, so this needs a new tag to take effect. Nothing reached PyPI, so no version was consumed there.

Worth considering separately: pinning hatchling in `[build-system] requires` so a build-backend release cannot change the artifacts mid-release again.